### PR TITLE
fix extra few shots bug

### DIFF
--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -132,11 +132,12 @@ class Task(Registrable, ABC):
 
         r = Random(random_seed)
         instances = self.get_split(self.fewshot_instances_split)
-        return [
+        sampled_instances = [
             instance
             for instance in r.sample(instances, num_shots + len(exceptions))
             if det_hash(instance) not in exceptions
         ]
+        return sampled_instances[:num_shots]
 
     #
     # builder-style methods


### PR DESCRIPTION
This fixes a bug where more than the specified number of few shots were included. Specifically, extra shots are sampled to account for possibly excluded exceptions examples, but if the exceptions don't occur the extra samples were still left in.

This change instead throws away extra samples if they are not needed.

# very basic performance test
## Before the change
```
python -m catwalk --model rc::gpt2 --task piqa --limit 100 --num_shots 0
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 244.03it/s]
Running log-likelihood queries: 100%|##########| 200/200 [00:48<00:00,  4.13it/s]
Calculating metrics: 100%|##########| 100/100 [00:00<00:00, 1114.48it/s]
piqa    acc     0.6399999856948853
```
## After the change
```
python -m catwalk --model rc::gpt2 --task piqa --limit 100 --num_shots 1
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 239.87it/s]
Running log-likelihood queries: 100%|##########| 200/200 [00:48<00:00,  4.11it/s]
Calculating metrics: 100%|##########| 100/100 [00:00<00:00, 1041.62it/s]
piqa    acc     0.6399999856948853

python -m catwalk --model rc::gpt2 --task piqa --limit 100 --num_shots 0
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 206.24it/s]
Running log-likelihood queries: 100%|##########| 200/200 [00:24<00:00,  8.06it/s]
Calculating metrics: 100%|##########| 100/100 [00:00<00:00, 1105.61it/s]
piqa    acc     0.6299999952316284
```


## Conclusion
We can see that the metrics are identical for zero shot before the change and one shot after the change. This is because with zero shot the model was actually running with one additional shot. This is because there is a single exception case (the test example that the few shots would be prepended to) but this exception would not occur (few shots and test examples come from different splits in this run).

And we can see that zero shot after the change is not identical as before now that it actually performs zero shot instead of one shot. The metrics are comparable which is expected for gpt2, which would exhibit little difference between zero and one shot performance.