### PR TITLE
Change default logging level to WARNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+
+- set default logging level to `"WARNING"` instead of `"ERROR"` when invoking `python -m catwalk`
 
 ### Added
 

--- a/catwalk/__main__.py
+++ b/catwalk/__main__.py
@@ -8,7 +8,7 @@ from catwalk.tasks import TASK_SETS
 
 
 def main():
-    initialize_logging()
+    initialize_logging(log_level="WARNING")
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--model', type=str, required=True)


### PR DESCRIPTION
This will change the default logging level when invoking `python -m catwalk` to `"WARNING"` instead of `"ERRORS"`. This prevents warnings from being suppressed.