### PR TITLE
Make MetaICLTasks work with general test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- MetaICLTask now supports fewshots less than 16 and only support getting the test split
 
 ### Added
 

--- a/catwalk/tasks/metaicl.py
+++ b/catwalk/tasks/metaicl.py
@@ -53,6 +53,10 @@ class MetaICLTask(Task):
         if num_shots == 0:
             return []
         assert random_seed in [100, 13, 21, 42, 87] and num_shots <= 16, "Only prebuilt seeds supported for now"
+        
+        # For now we only have 16 shot cached so we just subsample it
+        subsample_num_shots = num_shots
+        num_shots = 16
 
         if exceptions is None:
             exceptions = []
@@ -68,7 +72,7 @@ class MetaICLTask(Task):
         assert len(ds) == num_shots
         assert not any(det_hash(instance) in exceptions for instance in ds), "MetaICL should never have overlap between inference and fewshot splits"
 
-        return ds[:num_shots]
+        return ds[:subsample_num_shots]
 
     def instance_as_rank_classification(
         self,

--- a/catwalk/tasks/metaicl.py
+++ b/catwalk/tasks/metaicl.py
@@ -21,7 +21,7 @@ class MetaICLTask(Task):
         self.add_instance_conversion(InstanceFormat.RANK_CLASSIFICATION, self.instance_as_rank_classification)
         
     def has_split(self, split: str) -> bool:
-         return split in ['dev', 'test']
+         return split in ['test']
 
     @property
     def fewshot_instances_split(self) -> str:
@@ -36,6 +36,7 @@ class MetaICLTask(Task):
         return datasets.load_dataset('allenai/metaicl-data', data_files=data_files, split=split)
 
     def get_split(self, split: str) -> Sequence[Dict[str, Any]]:
+        assert self.has_split(split)
         ds = self._get_dataset(num_shots=16, fewshot_seed=100, split=split)
         # HF datasets are not sequences, even though they sometimes pretend they are. So we apply this hack
         # to make them act like sequences.
@@ -51,7 +52,7 @@ class MetaICLTask(Task):
     ) -> Sequence[Dict[str, Any]]:
         if num_shots == 0:
             return []
-        assert random_seed in [100, 13, 21, 42, 87] and num_shots == 16, "Only prebuilt seeds supported for now"
+        assert random_seed in [100, 13, 21, 42, 87] and num_shots <= 16, "Only prebuilt seeds supported for now"
 
         if exceptions is None:
             exceptions = []
@@ -67,7 +68,7 @@ class MetaICLTask(Task):
         assert len(ds) == num_shots
         assert not any(det_hash(instance) in exceptions for instance in ds), "MetaICL should never have overlap between inference and fewshot splits"
 
-        return ds
+        return ds[:num_shots]
 
     def instance_as_rank_classification(
         self,

--- a/tests/test_all_tasks.py
+++ b/tests/test_all_tasks.py
@@ -26,5 +26,5 @@ def test_task(task_name: str, split: str):
             if "num_fewshot" in signature.parameters:
                 kwargs["num_fewshot"] = 0
             if "fewshot_instances" in signature.parameters:
-                kwargs["fewshot_instances"] = task.get_fewshot_instances(2 if not task_name.startswith("metaicl::") else 16, exceptions=instance)
+                kwargs["fewshot_instances"] = task.get_fewshot_instances(2, exceptions=instance)
             assert conversion(instance, **kwargs) is not None


### PR DESCRIPTION
I made the following two changes to allow MetaICLTask to work with out special test case args in `test_all_tasks.py`:

1. I made MetaICLTasks support fewshots <=16 instead of just 16 or 0.
2. I made MetaICLTasks only allow the 'test' split to be accessed by `get_split()`. While there is also a dev split, its use is unclear because it only consists of 16 examples and would require specifying the fewshot seed to the task constructor (dev is randomly sampled while test is always the full test set). Thus for now I just block it, as I hope to resolve this all better once we can move away from using the cached data in the HF dataset and instead generate data programmatically.