### PR TITLE
fix rank classification likelihood averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed bug causing few-shot to use more than specified number of shots
+- Fixed bug where rank classification log likelihoods were being averaged by choice character length rather than token length
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/models/rank_classification.py
+++ b/catwalk/models/rank_classification.py
@@ -305,7 +305,7 @@ class DecoderOnlyRCModel(RankClassificationModel):
                 for i, instance_logits, input_length, instance_context, instance_continuation in z:
                     instance_logits = instance_logits[input_length-len(instance_continuation):input_length]
                     instance_logits = torch.gather(instance_logits, 1, instance_continuation.unsqueeze(-1))
-                    results[i] = float(instance_logits.sum()) / len(tuples[i][1])
+                    results[i] = float(instance_logits.sum()) / len(tokenized_continuations.input_ids[i])
 
         assert None not in results
         return cast(Sequence[float], results)


### PR DESCRIPTION
Previously rank classification was averaging by dividing the sum of token log likelihoods in continuations by the _character_ length of the the continuations. This PR changes instead averages by dividing the sum of token log likelihoods in continuations by the _token_ length of the the continuations.

This change is required to reproduce reported metrics in MetaICL, and would likely be needed to reproduce other results. To my knowledge no work would utilize the previous character length average, so I don't believe it needs to be retained as an option.

## reproduction results

Reported MetaICL on non-class-to-class setting avg macro f1: 38.1
Avg macro f1 if you rerun their repo for this setting: 38.2

Our reproduced result before this fix: 40.2741
Our reproduced result after this fix: 38.248