### PR TITLE
fix cached transformer override_weights_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed bug causing few-shot to use more than specified number of shots
+- Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -98,11 +98,9 @@ def get(
                     )
                 override_weights = {strip_prefix(k): override_weights[k] for k in valid_keys}
 
-            transformer = cls.from_config(  # type: ignore
-                cls.from_pretrained(  # type: ignore
-                    model_name,
-                    **kwargs,
-                )
+            transformer = cls.from_pretrained(  # type: ignore
+                model_name,
+                **kwargs,
             )
             # When DistributedDataParallel or DataParallel is used, the state dict of the
             # DistributedDataParallel/DataParallel wrapper prepends "module." to all parameters


### PR DESCRIPTION
Fixed bug in cached_transformer.get() that prevented using override_weights_file arg.

## problem

Running with any `override_weights_file` causes the following code to crash because `.from_config` cannot load from a model class:
```python
 transformer = cls.from_config(  # type: ignore
                cls.from_pretrained(  # type: ignore
                    model_name,
                    **kwargs,
                )
```

## traceback

```
File "/home/ianm/hn-icl/catwalk/catwalk/models/metaicl.py", line 37, in _make_model                                                                                      
return cached_transformers.get(AutoModelForCausalLM, pretrained_model_name_or_path, False, override_weights_file=self.model_params_file)                               
File "/home/ianm/hn-icl/catwalk/catwalk/cached_transformers.py", line 101, in get                                                                                        
transformer = cls.from_config(                                                                                                                                         
File "/home/ianm/miniconda3/envs/hn-icl/lib/python3.9/site-packages/transformers/models/auto/auto_factory.py", line 412, in from_config                                  
raise ValueError(                                                                                                                                                      
ValueError: Unrecognized configuration class <class 'transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel'> for this kind of AutoModel:                                  
AutoModelForCausalLM.                                                                                                                                                      
Model type should be one of BartConfig, BertConfig, BertGenerationConfig, BigBirdConfig, BigBirdPegasusConfig, BlenderbotConfig, BlenderbotSmallConfig,                    
BloomConfig, CamembertConfig, CTRLConfig, Data2VecTextConfig, ElectraConfig, GPT2Config, GPTNeoConfig, GPTNeoXConfig, GPTJConfig, MarianConfig, MBartConfig,               
MegatronBertConfig, OpenAIGPTConfig, OPTConfig, PegasusConfig, PLBartConfig, ProphetNetConfig, QDQBertConfig, ReformerConfig, RemBertConfig, RobertaConfig,                
RoFormerConfig, Speech2Text2Config, TransfoXLConfig, TrOCRConfig, XGLMConfig, XLMConfig, XLMProphetNetConfig, XLMRobertaConfig, XLMRobertaXLConfig,                        
XLNetConfig.
```