### PR TITLE
Optional random_subsample_seed for PredictStep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQuAD and SQuADShifts tasks
 - Adds a new MetaICLTask that supports the evaluation classification tasks in that benchmark
 - Adds a new MetaICLModel that replicates the formatting and truncation used by MetaICL for few shot evaluation
-- Optional random_subsample_seed for PrefixCache
+- Optional random_subsample_seed for PredictStep
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQuAD and SQuADShifts tasks
 - Adds a new MetaICLTask that supports the evaluation classification tasks in that benchmark
 - Adds a new MetaICLModel that replicates the formatting and truncation used by MetaICL for few shot evaluation
+- Optional random_subsample_seed for PrefixCache
 
 ### Fixed
 


### PR DESCRIPTION
Adds an optional random_subsample_seed for PredictStep, that causes the limit option to sample randomly rather than just taking the first n examples. This feature is required to reproduce subsampled datasets from MetaICL, and may be useful for future users.