### PR TITLE
implement load_weights for cached_transforers.get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing few-shot to use more than specified number of shots
 - Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
 - Fixed bug where rank classification log likelihoods were being averaged by choice character length rather than token length
+- Fixed the `load_weights` arg in cached_transformers.get() which was documented but not implemented
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -76,7 +76,10 @@ def get(
     )
     transformer = _model_cache.get(spec, None)
     if transformer is None:
-        if override_weights_file is not None:
+        if not load_weights:
+            config = transformers.AutoConfig.from_pretrained(model_name, **kwargs)
+            transformer = cls.from_config(config)   # type: ignore
+        elif override_weights_file is not None:
             override_weights_file = cached_path(override_weights_file)
             override_weights = torch.load(override_weights_file)
             if override_weights_strip_prefix is not None:
@@ -119,9 +122,6 @@ def get(
                 model_name,
                 **kwargs,
             )
-
-        if not load_weights:
-            transformer = cls.from_config(transformer.config)
 
         _model_cache[spec] = transformer
     if make_copy:

--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -102,10 +102,9 @@ def get(
                     )
                 override_weights = {strip_prefix(k): override_weights[k] for k in valid_keys}
 
-            transformer = cls.from_pretrained(  # type: ignore
-                model_name,
-                **kwargs,
-            )
+            # load from config to avoid loading default weights
+            config = transformers.AutoConfig.from_pretrained(model_name, **kwargs)
+            transformer = cls.from_config(config)   # type: ignore
             # When DistributedDataParallel or DataParallel is used, the state dict of the
             # DistributedDataParallel/DataParallel wrapper prepends "module." to all parameters
             # of the actual model, since the actual model is stored within the module field.

--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -15,13 +15,15 @@ class TransformerSpec:
     model_name: str
     override_weights_file: Optional[str] = None
     override_weights_strip_prefix: Optional[str] = None
+    load_weights: bool = True
 
     def __hash__(self):
         return hash((
             f"{self.cls.__module__}.{self.cls.__name__}",
             self.model_name,
             self.override_weights_file,
-            self.override_weights_strip_prefix
+            self.override_weights_strip_prefix,
+            self.load_weights
         ))
 
 
@@ -37,6 +39,7 @@ def get(
     make_copy: bool,
     override_weights_file: Optional[str] = None,
     override_weights_strip_prefix: Optional[str] = None,
+    load_weights: bool = True,
     **kwargs,
 ) -> T:
     """
@@ -69,6 +72,7 @@ def get(
         model_name,
         override_weights_file,
         override_weights_strip_prefix,
+        load_weights
     )
     transformer = _model_cache.get(spec, None)
     if transformer is None:
@@ -116,6 +120,10 @@ def get(
                 model_name,
                 **kwargs,
             )
+
+        if not load_weights:
+            transformer = cls.from_config(transformer.config)
+
         _model_cache[spec] = transformer
     if make_copy:
         import copy


### PR DESCRIPTION
Fixed the `load_weights` arg in cached_transformers.get() which was documented but not implemented
Resolves #63

Simple testing shows that with and without load_weights cache seperately:
```
>>> m1 = cached_transformers.get(transformers.AutoModel, 'bert-base-cased', False)
Some weights of the model checkpoint at bert-base-cased were not used when initializing BertModel: ['cls.predictions.transform.dense.weight', 'cls.predictions.bias', 'cls.seq_relationship.weight', 'cls.predictions.transform.dense.bias', 'cls.seq_relationship.bias', 'cls.predictions.decoder.weight', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.transform.LayerNorm.bias']
- This IS expected if you are initializing BertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing BertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
>>> m2 = cached_transformers.get(transformers.AutoModel, 'bert-base-cased', False)
>>> m3 = cached_transformers.get(transformers.AutoModel, 'bert-base-cased', False, load_weights=False)
>>> m4 = cached_transformers.get(transformers.AutoModel, 'bert-base-cased', False, load_weights=False)
>>> def model_eq(a,b):
...         return all(torch.allclose(p1 ,p2) for p1, p2 in zip(a.parameters(), b.parameters()))
>>> model_eq(m1,m2)
True
>>> model_eq(m1,m3)
False
>>> model_eq(m3,m4)
True
```