### PR TITLE
add likelihood_avging option to RankClassification models with 2 strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds a new MetaICLTask that supports the evaluation classification tasks in that benchmark
 - Adds a new MetaICLModel that replicates the formatting and truncation used by MetaICL for few shot evaluation
 - Optional random_subsample_seed for PredictStep
+- An option for rank classification to average log likelihoods by token length
 
 ### Fixed
 
 - Fixed bug causing few-shot to use more than specified number of shots
 - Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
-- Fixed bug where rank classification log likelihoods were being averaged by choice character length rather than token length
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/models/metaicl.py
+++ b/catwalk/models/metaicl.py
@@ -16,12 +16,12 @@ class MetaICLModel(DecoderOnlyRCModel):
         self,
         pretrained_model_name_or_path: str,
         *,
-        likelihood_avging: str = 'tok',
+        likelihood_averaging: str = 'token',
         max_length_per_example: int = 256,
         continuation_seperator: str = '\n',
         example_seperator: str = '\n\n\n'
     ):
-        super().__init__(pretrained_model_name_or_path, likelihood_avging=likelihood_avging)
+        super().__init__(pretrained_model_name_or_path, likelihood_averaging=likelihood_averaging)
         self.max_length_per_example = max_length_per_example
         self.continuation_seperator = continuation_seperator
         self.example_seperator = example_seperator

--- a/catwalk/models/metaicl.py
+++ b/catwalk/models/metaicl.py
@@ -16,11 +16,12 @@ class MetaICLModel(DecoderOnlyRCModel):
         self,
         pretrained_model_name_or_path: str,
         *,
+        likelihood_avging: str = 'tok',
         max_length_per_example: int = 256,
         continuation_seperator: str = '\n',
         example_seperator: str = '\n\n\n'
     ):
-        super().__init__(pretrained_model_name_or_path)
+        super().__init__(pretrained_model_name_or_path, likelihood_avging=likelihood_avging)
         self.max_length_per_example = max_length_per_example
         self.continuation_seperator = continuation_seperator
         self.example_seperator = example_seperator

--- a/catwalk/models/rank_classification.py
+++ b/catwalk/models/rank_classification.py
@@ -21,10 +21,10 @@ _Tokenizer = Union[T5TokenizerFast, GPT2Tokenizer]
 class RankClassificationModel(Model):
     VERSION = "001nul"
 
-    def __init__(self, pretrained_model_name_or_path: str, *, likelihood_avging: str = 'char'):
-        assert likelihood_avging in {'char', 'tok'}
+    def __init__(self, pretrained_model_name_or_path: str, *, likelihood_averaging: str = 'char'):
+        assert likelihood_avging in {'char', 'token'}
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
-        self.likelihood_avging = likelihood_avging
+        self.likelihood_averaging = likelihood_averaging
 
     @classmethod
     def _make_model(cls, pretrained_model_name_or_path: str) -> _Model:
@@ -229,7 +229,7 @@ class EncoderDecoderRCModel(RankClassificationModel):
                 for i, instance_logits, decoder_input_ids in zip(batch_of_indices, batch_logits, unpadded_batch["labels"]):
                     instance_logits = instance_logits[:len(decoder_input_ids)]
                     instance_logits = torch.gather(instance_logits, 1, decoder_input_ids.unsqueeze(-1))
-                    denom = len(tuples[i][1]) if self.likelihood_avging == 'char' else len(decoder_input_ids)
+                    denom = len(tuples[i][1]) if self.likelihood_averaging == 'char' else len(decoder_input_ids)
                     results[i] = float(instance_logits.sum()) / denom
 
         assert None not in results
@@ -308,7 +308,7 @@ class DecoderOnlyRCModel(RankClassificationModel):
                 for i, instance_logits, input_length, instance_context, instance_continuation in z:
                     instance_logits = instance_logits[input_length-len(instance_continuation):input_length]
                     instance_logits = torch.gather(instance_logits, 1, instance_continuation.unsqueeze(-1))
-                    denom = len(tuples[i][1]) if self.likelihood_avging == 'char' else len(instance_continuation)
+                    denom = len(tuples[i][1]) if self.likelihood_averaging == 'char' else len(instance_continuation)
                     results[i] = float(instance_logits.sum()) / denom
 
         assert None not in results

--- a/catwalk/models/rank_classification.py
+++ b/catwalk/models/rank_classification.py
@@ -22,7 +22,7 @@ class RankClassificationModel(Model):
     VERSION = "001nul"
 
     def __init__(self, pretrained_model_name_or_path: str, *, likelihood_averaging: str = 'char'):
-        assert likelihood_avging in {'char', 'token'}
+        assert likelihood_averaging in {'char', 'token'}
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.likelihood_averaging = likelihood_averaging
 

--- a/catwalk/models/rank_classification.py
+++ b/catwalk/models/rank_classification.py
@@ -21,8 +21,10 @@ _Tokenizer = Union[T5TokenizerFast, GPT2Tokenizer]
 class RankClassificationModel(Model):
     VERSION = "001nul"
 
-    def __init__(self, pretrained_model_name_or_path: str):
+    def __init__(self, pretrained_model_name_or_path: str, *, likelihood_avging: str = 'char'):
+        assert likelihood_avging in {'char', 'tok'}
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.likelihood_avging = likelihood_avging
 
     @classmethod
     def _make_model(cls, pretrained_model_name_or_path: str) -> _Model:
@@ -227,7 +229,8 @@ class EncoderDecoderRCModel(RankClassificationModel):
                 for i, instance_logits, decoder_input_ids in zip(batch_of_indices, batch_logits, unpadded_batch["labels"]):
                     instance_logits = instance_logits[:len(decoder_input_ids)]
                     instance_logits = torch.gather(instance_logits, 1, decoder_input_ids.unsqueeze(-1))
-                    results[i] = float(instance_logits.sum()) / len(tuples[i][1])
+                    denom = len(tuples[i][1]) if self.likelihood_avging == 'char' else len(decoder_input_ids)
+                    results[i] = float(instance_logits.sum()) / denom
 
         assert None not in results
         return cast(Sequence[float], results)
@@ -305,7 +308,8 @@ class DecoderOnlyRCModel(RankClassificationModel):
                 for i, instance_logits, input_length, instance_context, instance_continuation in z:
                     instance_logits = instance_logits[input_length-len(instance_continuation):input_length]
                     instance_logits = torch.gather(instance_logits, 1, instance_continuation.unsqueeze(-1))
-                    results[i] = float(instance_logits.sum()) / len(tokenized_continuations.input_ids[i])
+                    denom = len(tuples[i][1]) if self.likelihood_avging == 'char' else len(instance_continuation)
+                    results[i] = float(instance_logits.sum()) / denom
 
         assert None not in results
         return cast(Sequence[float], results)


### PR DESCRIPTION
This PR turns the changes made in #58 into an optional constructor argument of RC models to allow both character and token length averaging to be performed if needed. This address the immediate concerns raised by @dirkgr [here](https://github.com/allenai/catwalk/pull/58#issuecomment-1194877438).

Default behavior for RankClassificationModels returns to character length averaging as before #58. Meanwhile MetaICLModels default to the new token length averaging behavior as this is required to reproduce their results.