### PR TITLE
Distributed Data Parallel Training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing few-shot to use more than specified number of shots
 - Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
 - Fixed the `load_weights` arg in cached_transformers.get() which was documented but not implemented
+- Fixed support for distributed training with data parallelism (without parallelism for validation)
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/model.py
+++ b/catwalk/model.py
@@ -23,6 +23,7 @@ class Model(Registrable, DetHashWithVersion, ABC):
         predictions: Sequence[Dict[str, Any]],
         *,
         disable_torchmetrics_distributed_sync: bool = False,
+        **kwargs
         ) -> Dict[str, torch.Tensor]:
         # Annoyingly, torchmetrics only supports tensors as input, not raw values. So we have to convert raw values
         # into tensors.

--- a/catwalk/models/eleuther.py
+++ b/catwalk/models/eleuther.py
@@ -254,7 +254,7 @@ class EAIGPT(Model):
 
         return results
 
-    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]], **kwargs) -> Dict[str, float]:
         assert isinstance(task, EleutherTask), "We can only calculate metrics for EleutherTasks."
         return {
             key: fn([p[key] for p in predictions])
@@ -431,7 +431,7 @@ class EAIT5(Model):
     ) -> Sequence:
         raise NotImplementedError
 
-    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]], **kwargs) -> Dict[str, float]:
         assert isinstance(task, EleutherTask), "We can only calculate metrics for EleutherTasks."
         return {
             key: fn([p[key] for p in predictions])

--- a/catwalk/steps.py
+++ b/catwalk/steps.py
@@ -260,8 +260,6 @@ class FinetuneStep(Step):
             state = torch.load(train_config.final_weights_path, map_location="cpu")
             # We use `strict=False` because there might be missing keys due to weight tying.
             trainable_model.load_state_dict(state, strict=False)
-            # if distributed, this model hasn't been sent to device yet
-            trainable_model.to(resolve_device())
 
         return trainable_model
 

--- a/catwalk/steps.py
+++ b/catwalk/steps.py
@@ -22,6 +22,7 @@ from tango.integrations.torch import (
     DataLoader, TrainingEngine, TrainConfig,
 )
 from tango.integrations.torch.model import Model as TangoModel
+from tango.integrations.torch.util import resolve_device
 import torch
 
 from catwalk.task import Task
@@ -136,6 +137,8 @@ class FinetuneStep(Step):
         distributed_port: int = 54761,
         train_split: str = "train",
         validation_split: Optional[str] = "validation",
+        validate_every: int = 1000,
+        checkpoint_every: int = 1000
     ) -> Model:  # type: ignore
         if isinstance(model, str):
             model = MODELS[model]
@@ -169,8 +172,8 @@ class FinetuneStep(Step):
             validation_steps=validation_steps,
             train_split="train",
             validation_split=None if validation_split is None else "validation",
-            validate_every=1000,
-            checkpoint_every=1000,
+            validate_every=validate_every,
+            checkpoint_every=checkpoint_every,
             grad_accum=grad_accum,
             is_distributed=is_distributed,
             world_size=num_workers,
@@ -257,6 +260,8 @@ class FinetuneStep(Step):
             state = torch.load(train_config.final_weights_path, map_location="cpu")
             # We use `strict=False` because there might be missing keys due to weight tying.
             trainable_model.load_state_dict(state, strict=False)
+            # if distributed, this model hasn't been sent to device yet
+            trainable_model.to(resolve_device())
 
         return trainable_model
 

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -106,9 +106,13 @@ class Task(Registrable, ABC):
                 return split_name
         raise ValueError("This task has no split to take fewshot instances from.")
 
-    def make_metrics(self) -> Dict[str, torchmetrics.Metric]:
+    def make_metrics(
+            self,
+            *,
+            disable_torchmetrics_distributed_sync: bool = False
+        ) -> Dict[str, torchmetrics.Metric]:
         return {
-            name: metric_fn()
+            name: metric_fn(sync_on_compute= not disable_torchmetrics_distributed_sync)
             for name, metric_fn in self.metrics.items()
         }
 

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -75,7 +75,7 @@ class Task(Registrable, ABC):
     def __init__(self, *, version_override: Optional[str] = None):
         if version_override is not None:
             self.VERSION = version_override
-        self.metrics: Dict[str, Callable[[], torchmetrics.Metric]] = {}
+        self.metrics: Dict[str, Callable[..., torchmetrics.Metric]] = {}
         self.instance_conversions: Dict[InstanceFormat, InstanceConversion] = {}
 
     def det_hash_object(self) -> Any:

--- a/catwalk/train.py
+++ b/catwalk/train.py
@@ -1,5 +1,7 @@
 import argparse
 
+from tango.integrations.torch.util import resolve_device
+
 from tango import Workspace
 from tango.common.logging import initialize_logging
 
@@ -50,6 +52,8 @@ def main():
             device_count=args.device_count
         )
 
+    # Resolve to single device, because distributed evaluation is not supported
+    model_step = model_step.result().to(resolve_device())
     metric_task_dict = {}
     for task in tasks:
         predictions = PredictStep(model=model_step, task=task, batch_size=args.batch_size)

--- a/catwalk/train.py
+++ b/catwalk/train.py
@@ -15,6 +15,7 @@ def main():
     parser.add_argument("--task", type=str, nargs="+")
     parser.add_argument("--batch_size", type=int, default=16)
     parser.add_argument("--grad_acc", type=int, default=1)
+    parser.add_argument("--device_count", type=int, default=1)
     parser.add_argument(
         "-d",
         "-w",
@@ -41,7 +42,13 @@ def main():
         except KeyError:
             tasks.add(task)
 
-    model_step = FinetuneStep(model=args.model, tasks=tasks, batch_size=args.batch_size, grad_accum=args.grad_acc)
+    model_step = FinetuneStep(
+            model=args.model,
+            tasks=tasks,
+            batch_size=args.batch_size,
+            grad_accum=args.grad_acc,
+            device_count=args.device_count
+        )
 
     metric_task_dict = {}
     for task in tasks:

--- a/catwalk/training_callback.py
+++ b/catwalk/training_callback.py
@@ -23,16 +23,19 @@ class CatwalkEvaluationCallback(TrainCallback):
     def post_val_loop(
         self, step: int, epoch: int, val_metric: float, best_val_metric: float
     ) -> None:
+        if not self.is_local_main_process:
+            return
+
         model_was_training = self.model.training
         self.model.eval()
         try:
-            catwalk_model = cast(Model, self.model)
+            catwalk_model = cast(Model, self.model.module) if hasattr(self.model, "module") else cast(Model, self.model) 
             for task in self.tasks:
                 instances = task.get_split(self.eval_split)
                 if self.eval_limit is not None:
                     instances = instances[:self.eval_limit]
                 predictions = catwalk_model.predict(task, instances)
-                metrics = catwalk_model.calculate_metrics(task, list(predictions))
+                metrics = catwalk_model.calculate_metrics(task, list(predictions), disable_torchmetrics_distributed_sync=True)
                 metrics_string = []
                 for metric_name, metric_value in metrics.items():
                     if len(metric_value.shape) > 0:


### PR DESCRIPTION
## What is here

Fixes support for distributed training with data parallelism. Previously torch metrics would attempt to synchronize across processes during validation call back and would cause a crash. Also the final model output by the FinetuneStep would be on cpu rather than GPU as is the case for the non-distributed usage; now the returned model is on GPU.

## Limitations

Validation is still done in a single process with how data parallelism.

## Reproduction

Running with and without multiple devices produces exactly the same validation metrics, though the print out is slightly different due to tasks being copied:

`python -m catwalk.train --model rc::gpt2 --task piqa --device_count 1 --batch_size 16`

```
....
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 270.13it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 4003.12it/s]85.04it/s]
Metrics for piqa: acc: 0.647######  | 804/1000 [00:00<00:00, 4020.71it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 260.74it/s]_val_loss=3.02, val_loss=3.02]  
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 4000.07it/s]76.95it/s]
Metrics for piqa: acc: 0.648#####9  | 799/1000 [00:00<00:00, 3991.17it/s]
...
``` 

`python -m catwalk.train --model rc::gpt2 --task piqa --device_count 2 --batch_size 16`

```
...
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 271.48it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3683.20it/s]08.65it/s]
Metrics for <catwalk.tasks.eleuther.EleutherTask object at 0x7fe861c05490>: acc: 0.647
Running log-likelihood queries: 100%|##########| 2000/2000 [00:06<00:00, 288.04it/s]_val_loss=3.02, val_loss=3.02]  
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3767.45it/s]25.77it/s]
Metrics for <catwalk.tasks.eleuther.EleutherTask object at 0x7fe861c05490>: acc: 0.648
...
```

