### PR TITLE
Fairscale training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing few-shot to use more than specified number of shots
 - Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
 - Fixed the `load_weights` arg in cached_transformers.get() which was documented but not implemented
+- Fixed support for distributed training with data parallelism (without parallelism for validation)
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/model.py
+++ b/catwalk/model.py
@@ -23,6 +23,7 @@ class Model(Registrable, DetHashWithVersion, ABC):
         predictions: Sequence[Dict[str, Any]],
         *,
         disable_torchmetrics_distributed_sync: bool = False,
+        **kwargs
         ) -> Dict[str, torch.Tensor]:
         # Annoyingly, torchmetrics only supports tensors as input, not raw values. So we have to convert raw values
         # into tensors.

--- a/catwalk/models/eleuther.py
+++ b/catwalk/models/eleuther.py
@@ -254,7 +254,7 @@ class EAIGPT(Model):
 
         return results
 
-    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]], **kwargs) -> Dict[str, float]:
         assert isinstance(task, EleutherTask), "We can only calculate metrics for EleutherTasks."
         return {
             key: fn([p[key] for p in predictions])
@@ -431,7 +431,7 @@ class EAIT5(Model):
     ) -> Sequence:
         raise NotImplementedError
 
-    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    def calculate_metrics(self, task: Task, predictions: Sequence[Dict[str, Any]], **kwargs) -> Dict[str, float]:
         assert isinstance(task, EleutherTask), "We can only calculate metrics for EleutherTasks."
         return {
             key: fn([p[key] for p in predictions])

--- a/catwalk/steps.py
+++ b/catwalk/steps.py
@@ -22,6 +22,7 @@ from tango.integrations.torch import (
     DataLoader, TrainingEngine, TrainConfig,
 )
 from tango.integrations.torch.model import Model as TangoModel
+from tango.integrations.torch.util import resolve_device
 import torch
 
 from catwalk.task import Task
@@ -136,6 +137,8 @@ class FinetuneStep(Step):
         distributed_port: int = 54761,
         train_split: str = "train",
         validation_split: Optional[str] = "validation",
+        validate_every: int = 1000,
+        checkpoint_every: int = 1000
     ) -> Model:  # type: ignore
         if isinstance(model, str):
             model = MODELS[model]
@@ -169,8 +172,8 @@ class FinetuneStep(Step):
             validation_steps=validation_steps,
             train_split="train",
             validation_split=None if validation_split is None else "validation",
-            validate_every=1000,
-            checkpoint_every=1000,
+            validate_every=validate_every,
+            checkpoint_every=checkpoint_every,
             grad_accum=grad_accum,
             is_distributed=is_distributed,
             world_size=num_workers,
@@ -257,6 +260,8 @@ class FinetuneStep(Step):
             state = torch.load(train_config.final_weights_path, map_location="cpu")
             # We use `strict=False` because there might be missing keys due to weight tying.
             trainable_model.load_state_dict(state, strict=False)
+            # if distributed, this model hasn't been sent to device yet
+            trainable_model.to(resolve_device())
 
         return trainable_model
 

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -106,9 +106,13 @@ class Task(Registrable, ABC):
                 return split_name
         raise ValueError("This task has no split to take fewshot instances from.")
 
-    def make_metrics(self) -> Dict[str, torchmetrics.Metric]:
+    def make_metrics(
+            self,
+            *,
+            disable_torchmetrics_distributed_sync: bool = False
+        ) -> Dict[str, torchmetrics.Metric]:
         return {
-            name: metric_fn()
+            name: metric_fn(sync_on_compute= not disable_torchmetrics_distributed_sync)
             for name, metric_fn in self.metrics.items()
         }
 

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -75,7 +75,7 @@ class Task(Registrable, ABC):
     def __init__(self, *, version_override: Optional[str] = None):
         if version_override is not None:
             self.VERSION = version_override
-        self.metrics: Dict[str, Callable[[], torchmetrics.Metric]] = {}
+        self.metrics: Dict[str, Callable[..., torchmetrics.Metric]] = {}
         self.instance_conversions: Dict[InstanceFormat, InstanceConversion] = {}
 
     def det_hash_object(self) -> Any:

--- a/catwalk/train.py
+++ b/catwalk/train.py
@@ -2,9 +2,16 @@ import argparse
 
 from tango import Workspace
 from tango.common.logging import initialize_logging
+from tango.common import Lazy
+from tango.integrations.fairscale import FairScaleTrainingEngine, FSDPConfig, with_wrapped_modules
+from tango.integrations.torch import TorchTrainingEngine
 
 from catwalk.steps import TabulateMetricsStep, FinetuneStep
 from catwalk.tasks import TASK_SETS
+
+import transformers
+
+import torch
 
 
 def main():
@@ -16,6 +23,8 @@ def main():
     parser.add_argument("--batch_size", type=int, default=16)
     parser.add_argument("--grad_acc", type=int, default=1)
     parser.add_argument("--device_count", type=int, default=1)
+    parser.add_argument("--use_fairscale", action="store_true")
+    parser.add_argument("--modules_to_wrap", type=str, nargs="+")
     parser.add_argument(
         "-d",
         "-w",
@@ -26,6 +35,10 @@ def main():
         help="the Tango workspace with the cache",
     )
     args = parser.parse_args()
+
+    
+    assert not args.use_fairscale or (args.device_count >= 1), "use_fairscale is for distributed use only."
+    assert args.modules_to_wrap is None or args.use_fairscale, "modules_to_wrap requires use_fairscale."
 
     if args.workspace is None:
         workspace = None
@@ -42,13 +55,52 @@ def main():
         except KeyError:
             tasks.add(task)
 
+    lr_scheduler = Lazy(
+        transformers.optimization.get_linear_schedule_with_warmup,
+        num_warmup_steps=200,
+        num_training_steps=10000
+    )
+
+    optimizer = Lazy(
+        torch.optim.AdamW,
+        lr=1e-5,
+    )
+
+    fsdp_config = FSDPConfig(
+        reshard_after_forward=True,
+        move_params_to_cpu=True,
+        move_grads_to_cpu=True,
+        mixed_precision=False,
+    )
+
+    training_engine = Lazy(
+        FairScaleTrainingEngine,
+        lr_scheduler=lr_scheduler,
+        optimizer=optimizer,
+        # amp=True, # causes NaN
+        fsdp_config=fsdp_config
+    ) if args.use_fairscale else Lazy(
+        TorchTrainingEngine,
+        lr_scheduler=lr_scheduler,
+        optimizer=optimizer
+    )
+
+    model_wrapper = Lazy(
+        with_wrapped_modules,
+        modules_to_wrap=args.modules_to_wrap,
+        fsdp_config=fsdp_config,
+        activation_checkpointing=True
+    ) if args.use_fairscale and args.modules_to_wrap is not None else None
+
     model_step = FinetuneStep(
-            model=args.model,
-            tasks=tasks,
-            batch_size=args.batch_size,
-            grad_accum=args.grad_acc,
-            device_count=args.device_count
-        )
+        model=args.model,
+        tasks=tasks,
+        batch_size=args.batch_size,
+        grad_accum=args.grad_acc,
+        device_count=args.device_count,
+        training_engine=training_engine,
+        model_wrapper=model_wrapper
+    )
 
     metric_task_dict = {}
     for task in tasks:

--- a/catwalk/train.py
+++ b/catwalk/train.py
@@ -15,6 +15,7 @@ def main():
     parser.add_argument("--task", type=str, nargs="+")
     parser.add_argument("--batch_size", type=int, default=16)
     parser.add_argument("--grad_acc", type=int, default=1)
+    parser.add_argument("--device_count", type=int, default=1)
     parser.add_argument(
         "-d",
         "-w",
@@ -41,7 +42,13 @@ def main():
         except KeyError:
             tasks.add(task)
 
-    model_step = FinetuneStep(model=args.model, tasks=tasks, batch_size=args.batch_size, grad_accum=args.grad_acc)
+    model_step = FinetuneStep(
+            model=args.model,
+            tasks=tasks,
+            batch_size=args.batch_size,
+            grad_accum=args.grad_acc,
+            device_count=args.device_count
+        )
 
     metric_task_dict = {}
     for task in tasks:

--- a/catwalk/training_callback.py
+++ b/catwalk/training_callback.py
@@ -23,16 +23,19 @@ class CatwalkEvaluationCallback(TrainCallback):
     def post_val_loop(
         self, step: int, epoch: int, val_metric: float, best_val_metric: float
     ) -> None:
+        if not self.is_local_main_process:
+            return
+
         model_was_training = self.model.training
         self.model.eval()
         try:
-            catwalk_model = cast(Model, self.model)
+            catwalk_model = cast(Model, self.model.module) if hasattr(self.model, "module") else cast(Model, self.model) 
             for task in self.tasks:
                 instances = task.get_split(self.eval_split)
                 if self.eval_limit is not None:
                     instances = instances[:self.eval_limit]
                 predictions = catwalk_model.predict(task, instances)
-                metrics = catwalk_model.calculate_metrics(task, list(predictions))
+                metrics = catwalk_model.calculate_metrics(task, list(predictions), disable_torchmetrics_distributed_sync=True)
                 metrics_string = []
                 for metric_name, metric_value in metrics.items():
                     if len(metric_value.shape) > 0:


### PR DESCRIPTION
This draft code adds two arguments to `catwalk.train`. 1) the `--use_fairscale` flag uses a FairScaleTrainingEngine instead of a normal TorchTrainingEngine. 2) the `--modules_to_wrap" argument takes list of regex to for module names to wrap using Tango's `with_wrapped_modules`. Neither of these currently work fully.

## Problems

### Without wrapping modules

By itself `--use_fairscale` will train and reproduce validation metrics as follows. 

```
 python -m catwalk.train --model rc::gpt2 --task piqa --device_count 2 --use_fairscale 
...
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 262.34it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2167.71it/s]96.44it/s]
Step 999 metrics for <catwalk.tasks.eleuther.EleutherTask object at 0x7f0ac84373d0>: acc: 0.647
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 257.42it/s]st_val_loss=3.02, val_loss=3.02]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2078.94it/s]11.26it/s]
Step 1999 metrics for <catwalk.tasks.eleuther.EleutherTask object at 0x7f0ac84373d0>: acc: 0.648
...
```
```
 python -m catwalk.train --model rc::gpt2 --task piqa --device_count 2
....
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 270.13it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 4003.12it/s]85.04it/s]
Metrics for piqa: acc: 0.647######  | 804/1000 [00:00<00:00, 4020.71it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:07<00:00, 260.74it/s]_val_loss=3.02, val_loss=3.02]  
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 4000.07it/s]76.95it/s]
Metrics for piqa: acc: 0.648#####9  | 799/1000 [00:00<00:00, 3991.17it/s]
...
```

However it must run with amp/mixed_precision disabled to avoid NaNs in training. As such there is no memory footprint savings and the compute speed is lower than just not using fairscale. For instance with `gpt2` on `piqa` with 2 gpus and batch size 16, memory is at 31150MiB / 40536MiB without fairscale and at 30952MiB / 40536MiB with `--use_fairscale`.  

### With module wrapping

The modules to wrap can be specified like this: `python -m catwalk.train --model rc::gpt2 --task piqa --device_count 2 --use_fairscale --modules_to_wrap inner_module\\.transformer\\.h\\.\[0-9\]+`. However inside `catwalk_model.predict()` in `training_callback.py` the following error occurs:
```
RuntimeError: Expected all tensors to be on the same device, but found at                    
                             least two devices, cuda:0 and cpu! (when checking argument for argument index                
                             in method wrapper__index_select)   
```

The issue as I understand it is that our custom `.predict` code does not support the distributed communication necessary. But my understanding of the problem is limited.