### PR TITLE
support for opt in training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing few-shot to use more than specified number of shots
 - Fixed bug in cached_transformer.get() that prevented using override_weights_file arg
 - Fixed the `load_weights` arg in cached_transformers.get() which was documented but not implemented
+- Fixed support for training with OPT models
 
 ## [v0.1.0](https://github.com/allenai/catwalk/releases/tag/v0.1.0) - 2022-06-10
 

--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -155,6 +155,10 @@ def get_tokenizer(cls: Type[T], model_name: str, **kwargs) -> T:
     global _tokenizer_cache
     tokenizer = _tokenizer_cache.get(cache_key, None)
     if tokenizer is None:
+        # Currenty GPT2's fast tokenizer does NOT support adding a BOS token.                                                                                      
+        # This issue will be fixed soon, see: https://github.com/huggingface/tokenizers/pull/1005. so that the fast tokenizer works correctly.  
+        if model_name.startswith('facebook/opt'):
+            kwargs['use_fast'] = False
         tokenizer = cls.from_pretrained(  # type: ignore
             model_name,
             **kwargs,

--- a/catwalk/models/__init__.py
+++ b/catwalk/models/__init__.py
@@ -41,6 +41,7 @@ _ENCODER_DECODER_MODELS = {
 _DECODER_ONLY_MODELS = {
     "gpt2",
     "sshleifer/tiny-gpt2",
+    "facebook/opt-125m",
     "EleutherAI/gpt-j-6B",
     "gpt2-xl"
 }

--- a/catwalk/models/__init__.py
+++ b/catwalk/models/__init__.py
@@ -39,11 +39,26 @@ _ENCODER_DECODER_MODELS = {
 }
 
 _DECODER_ONLY_MODELS = {
-    "gpt2",
     "sshleifer/tiny-gpt2",
+    "gpt2",
+    "gpt2-medium",
+    "gpt2-large",
+    "gpt2-xl",
+    "bigscience/bloom-560m",
+    "bigscience/bloom-1b1",
+    "bigscience/bloom-1b7",
+    "bigscience/bloom-3b",
+    "bigscience/bloom-7b1",
+    "bigscience/bloom",
     "facebook/opt-125m",
+    "facebook/opt-350m",
+    "facebook/opt-1.3b",
+    "facebook/opt-2.7b",
+    "facebook/opt-6.7b",
+    "facebook/opt-13b",
+    "facebook/opt-30b",
+    "facebook/opt-66b",
     "EleutherAI/gpt-j-6B",
-    "gpt2-xl"
 }
 
 


### PR DESCRIPTION
## What's here

Fixes support for training with OPT models. The problem was that hugging face's implementation of OPT does not support the Fast Tokenizer. However our training code was making use of the `.sequence_ids()` method of the Fast Tokenizer. So this fix uses the `token_type_ids` instead.

## Results

`python -m catwalk.train --model opt-125m --task piqa`

```
100%|██████████| 3/3 [00:00<00:00, 528.43it/s]
Downloading pytorch_model.bin: 100%|██████████| 239M/239M [00:04<00:00, 52.4MB/s] 
Downloading tokenizer_config.json: 100%|██████████| 685/685 [00:00<00:00, 417kB/s]
Downloading vocab.json: 100%|██████████| 878k/878k [00:00<00:00, 959kB/s] 
Downloading merges.txt: 100%|██████████| 446k/446k [00:00<00:00, 824kB/s] 
Downloading special_tokens_map.json: 100%|██████████| 441/441 [00:00<00:00, 183kB/s]
Training:   0%|          | 0/10000 [00:00<?, ?it/s]Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 908.21it/s] 
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3327.00it/s]376.75it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 849.86it/s] val_loss=2.96, val_loss=2.96]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3372.51it/s]274.53it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 874.58it/s] val_loss=2.9, val_loss=2.9]  
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3372.63it/s]262.73it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 883.45it/s] val_loss=2.88, val_loss=2.88]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3352.59it/s]323.53it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 875.01it/s] al_loss=2.85, val_loss=2.85] 
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3438.12it/s]259.20it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 837.56it/s] val_loss=2.84, val_loss=2.84]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2450.38it/s]133.53it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 788.30it/s] val_loss=2.84, val_loss=2.84]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3311.31it/s]284.53it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 798.32it/s] val_loss=2.84, val_loss=2.85]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3339.08it/s]289.53it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 829.43it/s] val_loss=2.84, val_loss=2.84]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3421.75it/s]290.05it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:02<00:00, 848.95it/s] val_loss=2.82, val_loss=2.82]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3249.30it/s]331.40it/s]
Training: 100%|##########| 10000/10000 [32:58<00:00,  5.06it/s, batch_loss=2.42, best_loss=2.82, val_loss=2.84]   
Running log-likelihood queries: 100%|##########| 3676/3676 [00:06<00:00, 607.79it/s]
Calculating metrics: 100%|##########| 1838/1838 [00:01<00:00, 1005.54it/s]
Metrics for piqa: acc: 0.630
Metrics for piqa: acc: 0.635
Metrics for piqa: acc: 0.640
Metrics for piqa: acc: 0.643
Metrics for piqa: acc: 0.657
Metrics for piqa: acc: 0.657
Metrics for piqa: acc: 0.654
Metrics for piqa: acc: 0.660
Metrics for piqa: acc: 0.658
Metrics for piqa: acc: 0.659
piqa    acc     0.6512513756752014
```

## Reproduction

Validation metrics are exactly reproduced before and after the change

**Before the change**
```
python -m catwalk.train --model rc
::tiny-gpt2 --task piqa                                                                                                    
100%|███████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 593.42it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3880.42it/s]                                      
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3106.88it/s]879.48it/s]                                      
Metrics for piqa: acc: 0.523#######4| 945/1000 [00:00<00:00, 3137.31it/s]  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4258.78it/s]val_loss=10.8, val_loss=10.8] 
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2969.50it/s]312.86it/s]                                      
Metrics for piqa: acc: 0.525#######3| 937/1000 [00:00<00:00, 2965.23it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 2465.51it/s]val_loss=10.8, val_loss=10.8]         
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3013.35it/s]229.21it/s]                                      
Metrics for piqa: acc: 0.526#######2| 920/1000 [00:00<00:00, 3013.90it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4343.81it/s]val_loss=10.7, val_loss=10.7]         
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3075.39it/s]420.91it/s]                                      
Metrics for piqa: acc: 0.525#######4| 941/1000 [00:00<00:00, 3078.08it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4316.99it/s]val_loss=10.7, val_loss=10.7]         
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3100.90it/s]341.46it/s]                                      
Metrics for piqa: acc: 0.525#######6| 963/1000 [00:00<00:00, 3099.55it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4274.48it/s]val_loss=10.7, val_loss=10.7]         
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2914.30it/s]278.44it/s]                                      
Metrics for piqa: acc: 0.527######9 | 890/1000 [00:00<00:00, 2935.69it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4187.95it/s]val_loss=10.7, val_loss=10.7]         
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3012.34it/s]187.52it/s]                                      
Metrics for piqa: acc: 0.526#######2| 922/1000 [00:00<00:00, 3033.19it/s]                                                  
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4204.30it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3074.35it/s]288.38it/s]
Metrics for piqa: acc: 0.528#######2| 928/1000 [00:00<00:00, 3106.99it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2741.28it/s]030.43it/s]
Metrics for piqa: acc: 0.528######3 | 837/1000 [00:00<00:00, 2724.60it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 4025.25it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 3055.72it/s]999.43it/s]
Metrics for piqa: acc: 0.528#######3| 940/1000 [00:00<00:00, 3061.48it/s]
Training: 100%|##########| 10000/10000 [04:43<00:00, 35.22it/s, batch_loss=10.7, best_loss=10.7, val_loss=10.7]   
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
Running log-likelihood queries: 100%|##########| 3676/3676 [00:01<00:00, 3171.73it/s]
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
Calculating metrics: 100%|##########| 1838/1838 [00:02<00:00, 896.49it/s]
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
piqa    acc     0.5146898627281189
```


**After the change**
```
python -m catwalk.train --model rc::tiny-gpt2 --task piqa 
100%|███████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 195.40it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3606.52it/s]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2176.67it/s]681.13it/s]
Metrics for piqa: acc: 0.523#######1| 916/1000 [00:00<00:00, 2130.61it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3474.72it/s]val_loss=10.8, val_loss=10.8]  
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2334.60it/s]519.14it/s]
Metrics for piqa: acc: 0.525#######4| 947/1000 [00:00<00:00, 2349.31it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3312.09it/s]val_loss=10.8, val_loss=10.8]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2201.08it/s]331.68it/s]
Metrics for piqa: acc: 0.526######9 | 898/1000 [00:00<00:00, 2239.81it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3642.60it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2345.68it/s]694.84it/s]
Metrics for piqa: acc: 0.525#######6| 963/1000 [00:00<00:00, 2362.52it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3053.03it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2091.29it/s]171.27it/s]
Metrics for piqa: acc: 0.525######4 | 841/1000 [00:00<00:00, 2078.75it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3318.18it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 1988.78it/s]343.78it/s]
Metrics for piqa: acc: 0.527######5 | 853/1000 [00:00<00:00, 2010.85it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 2954.01it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 2042.67it/s]924.83it/s]
Metrics for piqa: acc: 0.526######2 | 823/1000 [00:00<00:00, 2072.04it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3315.21it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 1517.85it/s]382.11it/s]
Metrics for piqa: acc: 0.528####### | 902/1000 [00:00<00:00, 1610.19it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3376.56it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 1880.12it/s]470.43it/s]
Metrics for piqa: acc: 0.528######6 | 867/1000 [00:00<00:00, 1832.94it/s]
Running log-likelihood queries: 100%|##########| 2000/2000 [00:00<00:00, 3098.81it/s]val_loss=10.7, val_loss=10.7]
Calculating metrics: 100%|##########| 1000/1000 [00:00<00:00, 1932.04it/s]156.69it/s]
Metrics for piqa: acc: 0.528#######7| 972/1000 [00:00<00:00, 1941.23it/s]
Training: 100%|##########| 10000/10000 [09:03<00:00, 18.39it/s, batch_loss=10.7, best_loss=10.7, val_loss=10.7]   
Running log-likelihood queries: 100%|##########| 3676/3676 [00:01<00:00, 2740.37it/s]
Calculating metrics: 100%|##########| 1838/1838 [00:03<00:00, 529.14it/s]
piqa    acc     0.5146898627281189
```