### PR TITLE
run tests on Beaker with NFS cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,9 @@ jobs:
 
           - name: C
             mark: "suite_C"
+
+          - name: D
+            mark: "suite_D"
     steps:
       - name: Determine current commit SHA (pull request)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
-      - name: GPU Tests
+      - name: Tests
         uses: allenai/beaker-run-action@v1.1
         with:
           spec: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
                   - "--durations=5"
                   - "tests/"
                   - "-m"
-                  - "{{ matrix.test_suite.mark }}"
+                  - "${{ matrix.test_suite.mark }}"
                 constraints:
                   cluster:
                     - ai2/general-cirrascale

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,12 @@ env:
   DEFAULT_PYTHON: 3.9
   BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
   BEAKER_WORKSPACE: ai2/catwalk-tests
-  BEAKER_IMAGE: petew/catwalk-testing
+  BEAKER_IMAGE: petew/catwalk-testing  # to rebuild this image, run 'make docker-testing'
 
 jobs:
   checks:
     name: Python ${{ matrix.python }} - ${{ matrix.task.name }}
-    runs-on: [self-hosted, CPU-only]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -129,9 +129,9 @@ jobs:
                 context:
                   priority: preemptible
                 datasets:
-                  mountPath: /root/.cache
-                  source:
-                    hostPath: /net/nfs/allennlp/catwalk-cache
+                  - mountPath: /root/.cache
+                    source:
+                      hostPath: /net/nfs/allennlp/catwalk-cache
                 result:
                   path: /unused
           token: ${{ secrets.BEAKER_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ env:
   # Change this to invalidate existing cache.
   CACHE_PREFIX: v1
   PYTHON_PATH: ./
+  DEFAULT_PYTHON: 3.9
+  BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
+  BEAKER_WORKSPACE: ai2/catwalk-tests
+  BEAKER_IMAGE: petew/catwalk-testing
 
 jobs:
   checks:
@@ -32,10 +36,15 @@ jobs:
           - name: Build
             run: python setup.py check && python setup.py bdist_wheel sdist
 
-          - name: Test
-            run: pytest --forked -n4 -v --color=yes tests/
+          - name: Type check
+            run: mypy .
 
         include:
+          - task:
+              name: Test
+              run: pytest --forked -n4 -v --color=yes tests/
+            python: '3.10'
+
           - task:
               name: Type check
               run: mypy .
@@ -61,7 +70,7 @@ jobs:
           ${{ matrix.task.run }}
 
       - name: Upload package distribution files
-        if: matrix.task.name == 'Build'
+        if: matrix.task.name == 'Build' && matrix.python == env.DEFAULT_PYTHON
         uses: actions/upload-artifact@v3
         with:
           name: package
@@ -72,6 +81,61 @@ jobs:
         run: |
           . .venv/bin/activate
           pip uninstall -y ai2-catwalk
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine current commit SHA (pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
+      - name: Determine current commit SHA (push)
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+
+      - name: GPU Tests
+        uses: allenai/beaker-run-action@v1.1
+        with:
+          spec: |
+            version: v2
+            description: GPU Tests
+            tasks:
+              - name: tests
+                image:
+                  beaker: ${{ env.BEAKER_IMAGE }}
+                envVars:
+                  - name: COMMIT_SHA
+                    value: ${{ env.COMMIT_SHA }}
+                command:
+                  - "/entrypoint.sh"
+                  - "pytest"
+                  - "-v"
+                  - "--forked"
+                  - "-n4"
+                  - "--color=yes"
+                  - "--durations=5"
+                  - "tests/test_spotchecks.py"
+                  - "-k"
+                  - "rte"
+                constraints:
+                  cluster:
+                    - ai2/general-cirrascale
+                    - ai2/allennlp-cirrascale
+                    - ai2/aristo-cirrascale
+                    - ai2/mosaic-cirrascale
+                    - ai2/s2-cirrascale
+                context:
+                  priority: preemptible
+                datasets:
+                  mountPath: /root/.cache
+                  source:
+                    hostPath: /net/nfs/allennlp/catwalk-cache
+                result:
+                  path: /unused
+          token: ${{ secrets.BEAKER_TOKEN }}
+          workspace: ${{ env.BEAKER_WORKSPACE }}
 
   release:
     name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,7 @@ jobs:
                   - "--forked"
                   - "-n4"
                   - "--durations=5"
+                  - "--color=yes"
                   - "tests/"
                   - "-m"
                   - "${{ matrix.test_suite.mark }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   checks:
-    name: Python ${{ matrix.python }} - ${{ matrix.task.name }}
+    name: ${{ matrix.task.name }} (python ${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -115,7 +115,8 @@ jobs:
                   - "/entrypoint.sh"
                   - "pytest"
                   - "-v"
-                  - "--color=yes"
+                  - "--forked"
+                  - "-n4"
                   - "--durations=5"
                   - "tests/"
                   - "-m"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         test_suite:
           - name: A
-            mark: "not suite_B and not suite_C"
+            mark: "not suite_B and not suite_C and not suite_D"
 
           - name: B
             mark: "suite_B"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           spec: |
             version: v2
-            description: GPU Tests
+            description: Catwalk tests - suite ${{ matrix.test_suite.name }}
             tasks:
               - name: tests
                 image:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,16 +41,6 @@ jobs:
 
         include:
           - task:
-              name: Test
-              run: pytest --forked -n4 -v --color=yes tests/
-            python: '3.10'
-
-          - task:
-              name: Type check
-              run: mypy .
-            python: '3.10'
-
-          - task:
               name: Docs
               run: cd docs && make html SPHINXOPTS="-W --keep-going"
             python: '3.10'
@@ -82,8 +72,13 @@ jobs:
           . .venv/bin/activate
           pip uninstall -y ai2-catwalk
   tests:
-    name: Tests
+    name: Test - suite ${{ matrix.test_suite }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        test_suite: ["A", "B", "C"]
     steps:
       - name: Determine current commit SHA (pull request)
         if: github.event_name == 'pull_request'
@@ -116,9 +111,9 @@ jobs:
                   - "-n4"
                   - "--color=yes"
                   - "--durations=5"
-                  - "tests/test_spotchecks.py"
-                  - "-k"
-                  - "rte"
+                  - "tests/"
+                  - "-m"
+                  - "suite_${{ matrix.test_suite }}"
                 constraints:
                   cluster:
                     - ai2/general-cirrascale

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,13 +72,21 @@ jobs:
           . .venv/bin/activate
           pip uninstall -y ai2-catwalk
   tests:
-    name: Test - suite ${{ matrix.test_suite }}
+    name: Test - suite ${{ matrix.test_suite.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        test_suite: ["A", "B", "C"]
+        test_suite:
+          - name: A
+            mark: "not suite_B and not suite_C"
+
+          - name: B
+            mark: "suite_B"
+
+          - name: C
+            mark: "suite_C"
     steps:
       - name: Determine current commit SHA (pull request)
         if: github.event_name == 'pull_request'
@@ -107,13 +115,11 @@ jobs:
                   - "/entrypoint.sh"
                   - "pytest"
                   - "-v"
-                  - "--forked"
-                  - "-n4"
                   - "--color=yes"
                   - "--durations=5"
                   - "tests/"
                   - "-m"
-                  - "suite_${{ matrix.test_suite }}"
+                  - "{{ matrix.test_suite.mark }}"
                 constraints:
                   cluster:
                     - ai2/general-cirrascale

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,16 @@
+# This Dockerfile is for building an image suitable for running catwalk's tests.
+# There are no instruction lines in this Dockerfile that install catwalk. Instead, the entrypoint
+# script handles installing catwalk from a particular commit at runtime, based on the environment
+# variable "COMMIT_SHA". That way we don't need to rebuild and push the image each time we run
+# tests, and we can be sure the dependencies are always up-to-date.
+#
+# To rebuild and push this image to Beaker, run 'make docker-testing'.
+
+FROM ghcr.io/allenai/pytorch:1.13.0-cuda11.6-python3.9
+
+COPY scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /testing
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,11 @@ docs :
 run-checks :
 	mypy .
 	CUDA_VISIBLE_DEVICES='' pytest -v --color=yes --doctest-modules tests/ catwalk/
+
+
+.PHONY : docker-testing
+docker-testing :
+	docker build -t catwalk-testing -f Dockerfile.test .
+	beaker image create --workspace ai2/catwalk-tests --name catwalk-testing-tmp catwalk-testing
+	beaker image delete petew/catwalk-testing || true
+	beaker image rename petew/catwalk-testing-tmp catwalk-testing

--- a/catwalk/task.py
+++ b/catwalk/task.py
@@ -26,7 +26,7 @@ QA_METRICS = {
 
 
 try:
-    from functools import cache as memoize
+    from functools import cache as memoize  # type: ignore
 except ImportError:
     def memoize(user_function, /):      # type: ignore
         import functools

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,7 @@ python_classes = Test* *Test
 log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
 log_level = DEBUG
 markers =
+    suite_A: mark test to run with suite A
+    suite_B: mark test to run with suite B
+    suite_C: mark test to run with suite C
 filterwarnings =

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ markers =
     suite_A: mark test to run with suite A
     suite_B: mark test to run with suite B
     suite_C: mark test to run with suite C
+    suite_D: mark test to run with suite D
 filterwarnings =

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Exit script if any commands fail.
+set -e
+set -o pipefail
+
+# Check that the environment variable has been set correctly
+if [ -z "$COMMIT_SHA" ]; then
+  echo >&2 'error: missing COMMIT_SHA environment variable'
+  exit 1
+fi
+
+# Upgrade pip
+/opt/conda/bin/pip install --upgrade pip
+
+# Clone and install catwalk.
+git clone https://github.com/allenai/catwalk.git
+cd catwalk
+git checkout --quiet "$COMMIT_SHA"
+/opt/conda/bin/pip install --no-cache-dir '.[dev]'
+
+# Create directory for results.
+mkdir -p /results
+
+# Execute the arguments to this script as commands themselves, piping output into a log file.
+exec "$@" 2>&1 | tee /results/out.log

--- a/tests/test_all_tasks.py
+++ b/tests/test_all_tasks.py
@@ -10,10 +10,24 @@ from catwalk.tasks.huggingface import HFMCInstance
 
 from .util import suite_B, suite_C
 
+# These are tasks are known to fail for now due to an unreachable server.
+known_failures = {
+    "lambada_mt_en",
+    "lambada_mt_fr",
+    "lambada_mt_de",
+    "lambada_mt_it",
+    "lambada_mt_es",
+    "triviaqa",
+}
+
 # There are too many P3 tasks, so we just pick one.
 # MRQA dataset takes too long to load, so we skip it.
 task_names = [
-    task
+    pytest.param(
+        task,
+        id=task,
+        marks=pytest.mark.xfail if task in known_failures else None,  # type: ignore
+    )
     for task in catwalk.tasks.TASKS.keys()
     if not task.startswith("p3::") and not task.startswith("mrqa::")
 ]

--- a/tests/test_all_tasks.py
+++ b/tests/test_all_tasks.py
@@ -26,7 +26,7 @@ task_names = [
     pytest.param(
         task,
         id=task,
-        marks=pytest.mark.xfail if task in known_failures else None,  # type: ignore
+        marks=pytest.mark.xfail if task in known_failures else (),
     )
     for task in catwalk.tasks.TASKS.keys()
     if not task.startswith("p3::") and not task.startswith("mrqa::")

--- a/tests/test_all_tasks.py
+++ b/tests/test_all_tasks.py
@@ -3,21 +3,35 @@ from typing import Any, Dict, cast
 
 import pytest
 
-import catwalk.tasks
 import catwalk.models
+import catwalk.tasks
 from catwalk.task import InstanceFormat
 from catwalk.tasks.huggingface import HFMCInstance
 
+from .util import suite_B, suite_C
+
 # There are too many P3 tasks, so we just pick one.
 # MRQA dataset takes too long to load, so we skip it.
-task_names = [task for task in catwalk.tasks.TASKS.keys() if not task.startswith("p3::") and not task.startswith("mrqa::")]
+task_names = [
+    task
+    for task in catwalk.tasks.TASKS.keys()
+    if not task.startswith("p3::") and not task.startswith("mrqa::")
+]
 task_names.insert(0, "p3::wiki_qa_Is_This_True_")
 
 
 @pytest.mark.parametrize("task_name", task_names)
+@suite_B
 def test_task(task_name: str):
     task = catwalk.tasks.TASKS[task_name]
-    instances = next((task.get_split(split) for split in ["train", "validation", "test"] if task.has_split(split)), None)
+    instances = next(
+        (
+            task.get_split(split)
+            for split in ["train", "validation", "test"]
+            if task.has_split(split)
+        ),
+        None,
+    )
     if not instances:
         return
     for conversion in task.instance_conversions.values():
@@ -28,7 +42,9 @@ def test_task(task_name: str):
                 kwargs["num_fewshot"] = 0
             try:
                 if "fewshot_instances" in signature.parameters:
-                    kwargs["fewshot_instances"] = task.get_fewshot_instances(2, exceptions=instance)
+                    kwargs["fewshot_instances"] = task.get_fewshot_instances(
+                        2, exceptions=instance
+                    )
             except ValueError:  # This task doesn't support fewshot for the chosen split.
                 kwargs = {}
             assert conversion(instance, **kwargs) is not None
@@ -42,13 +58,18 @@ mc_tasks = [
 
 
 @pytest.mark.parametrize("task_name", mc_tasks)
+@suite_C
 def test_mc_tasks(task_name):
     task = catwalk.tasks.TASKS[task_name]
     for split in ["train", "validation", "test"]:
         if not task.has_split(split):
             continue
         for instance in task.get_split(split):
-            mc_instance = cast(HFMCInstance, task.convert_instance(instance, InstanceFormat.HF_MC))
+            mc_instance = cast(
+                HFMCInstance, task.convert_instance(instance, InstanceFormat.HF_MC)
+            )
             if mc_instance.correct_answer_index is not None:
                 assert mc_instance.correct_answer_index >= 0
-                assert mc_instance.correct_answer_index < len(mc_instance.answer_choices)
+                assert mc_instance.correct_answer_index < len(
+                    mc_instance.answer_choices
+                )

--- a/tests/test_spotchecks.py
+++ b/tests/test_spotchecks.py
@@ -1,11 +1,12 @@
-import sys
-
 import pytest
 
 import catwalk.__main__
 from catwalk.steps import PredictStep, CalculateMetricsStep
 
+from .util import suite_A
 
+
+@suite_A
 def test_squad():
     args = catwalk.__main__._parser.parse_args([
         "--model", "bert-base-uncased",
@@ -17,6 +18,7 @@ def test_squad():
 
 
 @pytest.mark.parametrize("task", ["mnli", "cola", "rte"])
+@suite_A
 def test_gpt2_performance(task: str):
     model = "rc::gpt2"
     predictions = PredictStep(model=model, task=task, limit=100)

--- a/tests/test_spotchecks.py
+++ b/tests/test_spotchecks.py
@@ -1,27 +1,33 @@
 import pytest
 
 import catwalk.__main__
-from catwalk.steps import PredictStep, CalculateMetricsStep
+from catwalk.steps import CalculateMetricsStep, PredictStep
 
-from .util import suite_A
+from .util import suite_C
 
 
-@suite_A
+@suite_C
 def test_squad():
-    args = catwalk.__main__._parser.parse_args([
-        "--model", "bert-base-uncased",
-        "--task", "squad",
-        "--split", "validation",
-        "--limit", "100"
-    ])
+    args = catwalk.__main__._parser.parse_args(
+        [
+            "--model",
+            "bert-base-uncased",
+            "--task",
+            "squad",
+            "--split",
+            "validation",
+            "--limit",
+            "100",
+        ]
+    )
     catwalk.__main__.main(args)
 
 
 @pytest.mark.parametrize("task", ["mnli", "cola", "rte"])
-@suite_A
+@suite_C
 def test_gpt2_performance(task: str):
     model = "rc::gpt2"
     predictions = PredictStep(model=model, task=task, limit=100)
     metrics = CalculateMetricsStep(model=model, task=task, predictions=predictions)
     results = metrics.result()
-    assert results['relative_improvement'] > 0
+    assert results["relative_improvement"] > 0

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -3,6 +3,8 @@ import pytest
 from catwalk import MODELS
 from catwalk.steps import PredictStep, CalculateMetricsStep
 
+from .util import suite_A
+
 task_names = [
     "arc_challenge",
     "boolq",
@@ -40,6 +42,7 @@ generation_params = [(t, m) for t in generation_task_names for m in generation_m
 params = params + generation_params
 
 @pytest.mark.parametrize("task_name,model_name", params)
+@suite_A
 def test_task_eval(task_name: str, model_name: str):
     if MODELS[model_name].supports_fewshot:
         predict_kwargs = {"num_shots": 3}

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -2,15 +2,15 @@ import torch
 from transformers import AdamW
 
 from catwalk import MODELS, TASKS
-from catwalk.steps import FinetuneStep, PredictStep, CalculateMetricsStep
+from catwalk.steps import CalculateMetricsStep, FinetuneStep, PredictStep
 
-from .util import suite_A
+from .util import suite_A, suite_D
 
 
-@suite_A
+@suite_D
 def test_training():
-    model = MODELS['rc::tiny-gpt2']
-    task = TASKS['piqa']
+    model = MODELS["rc::tiny-gpt2"]
+    task = TASKS["piqa"]
     instances = task.get_split("train")[:16]
     predictions_before = list(model.predict(task, instances))
     metrics_before = model.calculate_metrics(task, predictions_before)
@@ -35,45 +35,55 @@ def test_training():
 
     predictions_after = list(model.predict(task, instances))
     metrics_after = model.calculate_metrics(task, list(predictions_after))
-    for prediction_before, prediction_after in zip(predictions_before, predictions_after):
-        assert not torch.allclose(prediction_before["acc"][0], prediction_after["acc"][0])
+    for prediction_before, prediction_after in zip(
+        predictions_before, predictions_after
+    ):
+        assert not torch.allclose(
+            prediction_before["acc"][0], prediction_after["acc"][0]
+        )
     assert metrics_before != metrics_after
 
 
 @suite_A
 def test_training_step_gpt():
     finetune_step = FinetuneStep(
-        model='rc::tiny-gpt2',
+        model="rc::tiny-gpt2",
         tasks=["piqa", "sst"],
         train_steps=10,
         validation_steps=10,
     )
     predict_step = PredictStep(model=finetune_step, task="piqa", limit=10)
-    metrics_step = CalculateMetricsStep(model=finetune_step, task="piqa", predictions=predict_step)
+    metrics_step = CalculateMetricsStep(
+        model=finetune_step, task="piqa", predictions=predict_step
+    )
     metrics_step.result()
 
 
 @suite_A
 def test_training_step_t5():
     finetune_step = FinetuneStep(
-        model='rc::t5-very-small-random',
+        model="rc::t5-very-small-random",
         tasks=["rte", "boolq"],
         train_steps=10,
         validation_steps=10,
     )
     predict_step = PredictStep(model=finetune_step, task="rte", limit=10)
-    metrics_step = CalculateMetricsStep(model=finetune_step, task="rte", predictions=predict_step)
+    metrics_step = CalculateMetricsStep(
+        model=finetune_step, task="rte", predictions=predict_step
+    )
     metrics_step.result()
 
 
 @suite_A
 def test_training_step_hf():
     finetune_step = FinetuneStep(
-        model='tiny-bert',
+        model="tiny-bert",
         tasks=["piqa"],
         train_steps=10,
         validation_steps=10,
     )
     predict_step = PredictStep(model=finetune_step, task="piqa", limit=10)
-    metrics_step = CalculateMetricsStep(model=finetune_step, task="piqa", predictions=predict_step)
+    metrics_step = CalculateMetricsStep(
+        model=finetune_step, task="piqa", predictions=predict_step
+    )
     metrics_step.result()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,7 +4,10 @@ from transformers import AdamW
 from catwalk import MODELS, TASKS
 from catwalk.steps import FinetuneStep, PredictStep, CalculateMetricsStep
 
+from .util import suite_A
 
+
+@suite_A
 def test_training():
     model = MODELS['rc::tiny-gpt2']
     task = TASKS['piqa']
@@ -37,6 +40,7 @@ def test_training():
     assert metrics_before != metrics_after
 
 
+@suite_A
 def test_training_step_gpt():
     finetune_step = FinetuneStep(
         model='rc::tiny-gpt2',
@@ -49,6 +53,7 @@ def test_training_step_gpt():
     metrics_step.result()
 
 
+@suite_A
 def test_training_step_t5():
     finetune_step = FinetuneStep(
         model='rc::t5-very-small-random',
@@ -61,6 +66,7 @@ def test_training_step_t5():
     metrics_step.result()
 
 
+@suite_A
 def test_training_step_hf():
     finetune_step = FinetuneStep(
         model='tiny-bert',

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,7 +4,7 @@ from transformers import AdamW
 from catwalk import MODELS, TASKS
 from catwalk.steps import CalculateMetricsStep, FinetuneStep, PredictStep
 
-from .util import suite_A, suite_D
+from .util import suite_D
 
 
 @suite_D
@@ -44,7 +44,7 @@ def test_training():
     assert metrics_before != metrics_after
 
 
-@suite_A
+@suite_D
 def test_training_step_gpt():
     finetune_step = FinetuneStep(
         model="rc::tiny-gpt2",
@@ -59,7 +59,7 @@ def test_training_step_gpt():
     metrics_step.result()
 
 
-@suite_A
+@suite_D
 def test_training_step_t5():
     finetune_step = FinetuneStep(
         model="rc::t5-very-small-random",
@@ -74,7 +74,7 @@ def test_training_step_t5():
     metrics_step.result()
 
 
-@suite_A
+@suite_D
 def test_training_step_hf():
     finetune_step = FinetuneStep(
         model="tiny-bert",

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,3 +11,7 @@ def suite_B(test_method):
 
 def suite_C(test_method):
     return pytest.mark.suite_C(test_method)
+
+
+def suite_D(test_method):
+    return pytest.mark.suite_D(test_method)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def suite_A(test_method):
+    return pytest.mark.suite_A(test_method)
+
+
+def suite_B(test_method):
+    return pytest.mark.suite_B(test_method)
+
+
+def suite_C(test_method):
+    return pytest.mark.suite_C(test_method)


### PR DESCRIPTION
Changes proposed:
- Sets up unit tests to run on Beaker via [`beaker-run-action`](https://github.com/allenai/beaker-run-action) (this is what we use to run GPU tests on Beaker for Tango).
- Splits up tests to run in different suites, a CI job for each suite. This reduces CI runtime from 10+ minutes to 4 minutes and could be reduced even more by splitting off more suites. Note that suite A is the catch-all. Anything not explicitly marked for another suite will be put into A.

Once https://github.com/allenai/reconfig/issues/1166 is resolved we should update the cache location.