### PR TITLE
Add mmlu

### DIFF
--- a/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
+++ b/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
@@ -146,7 +146,9 @@ class GeneralHendrycksTest(MultipleChoiceTask):
              D. <choice4>
             Answer:
             """
-
+            # NOTE: We added the space before the answer key which is not present in the original
+            # Eleuther code base. We made this change to ensure that the token associated with the
+            # answer choices here exactly matches the answer token used for evaluation.
             question = doc["question"].strip()
             choices = "".join(
                 [f" {key}. {choice}\n" for key, choice in zip(keys, doc["choices"])]

--- a/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
+++ b/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
@@ -103,8 +103,8 @@ def create_task(subject):
 
 
 class GeneralHendrycksTest(MultipleChoiceTask):
-    VERSION = 0
-    DATASET_PATH = "hendrycks_test"
+    VERSION = 1
+    DATASET_PATH = "cais/mmlu"
     DATASET_NAME = None
 
     def __init__(self, subject):
@@ -112,7 +112,7 @@ class GeneralHendrycksTest(MultipleChoiceTask):
         super().__init__()
 
     def has_training_docs(self):
-        return False
+        return True
 
     def has_validation_docs(self):
         return True
@@ -126,41 +126,50 @@ class GeneralHendrycksTest(MultipleChoiceTask):
     def test_docs(self):
         return map(self._process_doc, self.dataset["test"])
 
+    def _format_subject(self, subject):
+        words = subject.split("_")
+        return " ".join(words)
+
+    def fewshot_context(self, doc, num_fewshot, **kwargs):
+        subject = self.DATASET_NAME
+        description = f"The following are multiple choice questions (with answers) about {self._format_subject(subject)}."
+        kwargs["description"] = description
+        return super().fewshot_context(doc=doc, num_fewshot=num_fewshot, **kwargs)
+
     def _process_doc(self, doc):
         def format_example(doc, keys):
             """
-            Question: <prompt>
-            Choices:
+            <prompt>
             A. <choice1>
             B. <choice2>
             C. <choice3>
             D. <choice4>
             Answer:
             """
-            prompt = "Question: " + doc["question"] + "\nChoices:\n"
-            prompt += "".join(
+
+            question = doc["question"].strip()
+            choices = "".join(
                 [f"{key}. {choice}\n" for key, choice in zip(keys, doc["choices"])]
             )
-            prompt += "Answer:"
+            prompt = f"{question}\n{choices}Answer:"
             return prompt
 
         keys = ["A", "B", "C", "D"]
         return {
             "query": format_example(doc, keys),
-            "choices": doc["choices"],
-            "gold": keys.index(doc["answer"])
-            if isinstance(doc["answer"], str)
-            else doc["answer"],
+            "choices": keys,
+            "gold": doc["answer"],
         }
 
     def fewshot_examples(self, k, rnd):
         # fewshot_examples is not just sampling from train_docs because dev is
         # in the same distribution as val/test but auxiliary_train isn't
-
         if self._fewshot_docs is None:
             self._fewshot_docs = list(map(self._process_doc, self.dataset["dev"]))
 
-        return rnd.sample(list(self._fewshot_docs), k)
+        # use the unchanged order of the dev set without sampling,
+        # just as in the original code https://github.com/hendrycks/test/blob/master/evaluate.py#L28
+        return self._fewshot_docs[:k]
 
     def doc_to_text(self, doc):
         return doc["query"]

--- a/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
+++ b/catwalk/dependencies/lm_eval/tasks/hendrycks_test.py
@@ -140,16 +140,16 @@ class GeneralHendrycksTest(MultipleChoiceTask):
         def format_example(doc, keys):
             """
             <prompt>
-            A. <choice1>
-            B. <choice2>
-            C. <choice3>
-            D. <choice4>
+             A. <choice1>
+             B. <choice2>
+             C. <choice3>
+             D. <choice4>
             Answer:
             """
 
             question = doc["question"].strip()
             choices = "".join(
-                [f"{key}. {choice}\n" for key, choice in zip(keys, doc["choices"])]
+                [f" {key}. {choice}\n" for key, choice in zip(keys, doc["choices"])]
             )
             prompt = f"{question}\n{choices}Answer:"
             return prompt

--- a/catwalk/models/eleuther.py
+++ b/catwalk/models/eleuther.py
@@ -163,8 +163,15 @@ class EAIGPT(Model):
                     for index in batch_of_indices:
                         for field_name, (context_ids, continuation_ids) in cc_pairs[index].items():
                             ids = torch.cat([context_ids, continuation_ids])
-                            ids = ids[-(tokenizer.model_max_length+1):][:-1]
+                            # Use truncation_length+1 since the last token is not in the input
+                            if len(ids) > (tokenizer.model_max_length+1):
+                                ids = ids[-(tokenizer.model_max_length+1):]
+                            ids = ids[:-1]
                             unpadded_batch[field_name].append(ids)
+                            # print(ids.shape())
+                            # print(tokenizer.model_max_length)
+                            # ids = ids[-(tokenizer.model_max_length+1):][:-1]
+                            # unpadded_batch[field_name].append(ids)
 
                         input_lengths.append(len(unpadded_batch["input_ids"][-1]))
                         batch_contexts.append(cc_pairs[index]["input_ids"][0])

--- a/catwalk/models/eleuther.py
+++ b/catwalk/models/eleuther.py
@@ -168,10 +168,6 @@ class EAIGPT(Model):
                                 ids = ids[-(tokenizer.model_max_length+1):]
                             ids = ids[:-1]
                             unpadded_batch[field_name].append(ids)
-                            # print(ids.shape())
-                            # print(tokenizer.model_max_length)
-                            # ids = ids[-(tokenizer.model_max_length+1):][:-1]
-                            # unpadded_batch[field_name].append(ids)
 
                         input_lengths.append(len(unpadded_batch["input_ids"][-1]))
                         batch_contexts.append(cc_pairs[index]["input_ids"][0])

--- a/catwalk/tasks/eleuther.py
+++ b/catwalk/tasks/eleuther.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional, Union, Callable, Sequence, List, TypeVar
 from tango.common.sequences import MappedSequence
 
 from catwalk.task import Task, InstanceFormat, RankClassificationInstance, WithAnswerOptionsMixin, \
-    classification_metrics
+    classification_metrics, rc_metrics
 from catwalk.tasks.promptsource import WithPromptsourceMixin
 
 from catwalk.dependencies.lm_eval.base import Task as EAITask
@@ -322,3 +322,75 @@ class EleutherClassificationTaskWithRenamedSplits(EleutherTaskWithRenamedSplits,
         self.add_metrics(classification_metrics(len(answer_options)))
 
     instance_as_rank_classification = EleutherClassificationTask.instance_as_rank_classification
+
+SUBJECTS = [
+    "abstract_algebra",
+    "anatomy",
+    "astronomy",
+    "business_ethics",
+    "clinical_knowledge",
+    "college_biology",
+    "college_chemistry",
+    "college_computer_science",
+    "college_mathematics",
+    "college_medicine",
+    "college_physics",
+    "computer_security",
+    "conceptual_physics",
+    "econometrics",
+    "electrical_engineering",
+    "elementary_mathematics",
+    "formal_logic",
+    "global_facts",
+    "high_school_biology",
+    "high_school_chemistry",
+    "high_school_computer_science",
+    "high_school_european_history",
+    "high_school_geography",
+    "high_school_government_and_politics",
+    "high_school_macroeconomics",
+    "high_school_mathematics",
+    "high_school_microeconomics",
+    "high_school_physics",
+    "high_school_psychology",
+    "high_school_statistics",
+    "high_school_us_history",
+    "high_school_world_history",
+    "human_aging",
+    "human_sexuality",
+    "international_law",
+    "jurisprudence",
+    "logical_fallacies",
+    "machine_learning",
+    "management",
+    "marketing",
+    "medical_genetics",
+    "miscellaneous",
+    "moral_disputes",
+    "moral_scenarios",
+    "nutrition",
+    "philosophy",
+    "prehistory",
+    "professional_accounting",
+    "professional_law",
+    "professional_medicine",
+    "professional_psychology",
+    "public_relations",
+    "security_studies",
+    "sociology",
+    "us_foreign_policy",
+    "virology",
+    "world_religions",
+]
+
+
+def create_mmlu_tasks():
+    """Creates a dictionary of tasks from a list of subjects
+    :return: {task_name: task}
+        e.g. {hendrycksTest-abstract_algebra: Task, hendrycksTest-anatomy: Task}
+    """
+    return {f"mmlu_test_{sub}": create_eleuther_task(f"hendrycksTest-{sub}") for sub in SUBJECTS}
+
+
+def create_eleuther_task(subject):
+     return EleutherTask(subject, ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw"))

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -7,7 +7,7 @@ from torchmetrics import MeanMetric
 from catwalk.task import InstanceFormat, ENTAILMENT_METRICS, QA_METRICS, Task, \
     classification_metrics, BINARY_CLASSIFICATION_METRICS, mc_metrics, rc_metrics, ppl_metrics, PERPLEXITY_METRICS
 from catwalk.tasks.eleuther import EleutherTask, RaceEleutherTask, EleutherTaskWithRenamedSplits, \
-    EleutherClassificationTask, EleutherClassificationTaskWithRenamedSplits
+    EleutherClassificationTask, EleutherClassificationTaskWithRenamedSplits, create_mmlu_tasks
 from catwalk.tasks.perplexity_jsonl import PerplexityJsonLTask
 from catwalk.tasks.huggingface import hfmc_conversion, HFDatasetsTask, hfqa_conversion, hfclassification_conversion
 from catwalk.tasks.p3 import P3Task
@@ -36,6 +36,8 @@ TASKS_LM: Dict[str, Task] = {
     "wic": EleutherClassificationTask("wic", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
     "wsc": EleutherClassificationTask("wsc", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
     "naturalqs_short_open": EleutherTask("naturalqs_short_open", eleuther_metrics=True, model_args = {"max_gen_toks": 50}),
+    # hendrycksTest (57 tasks)
+    **create_mmlu_tasks(),
     # "lambada": EleutherTask("lambada_standard").add_metrics(PERPLEXITY_METRICS).add_metric("acc", MeanMetric),
     # "pubmedqa": EleutherTaskWithRenamedSplits("pubmedqa").add_metrics(BINARY_CLASSIFICATION_METRICS),
     "sciq": EleutherTask("sciq", ranked_classification=True).add_metrics(rc_metrics(primary="acc_raw")),

--- a/catwalk/tasks/tasks_lm.py
+++ b/catwalk/tasks/tasks_lm.py
@@ -36,7 +36,7 @@ TASKS_LM: Dict[str, Task] = {
     "wic": EleutherClassificationTask("wic", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
     "wsc": EleutherClassificationTask("wsc", answer_options=["no", "yes"], metrics=rc_metrics(primary="acc_raw")),
     "naturalqs_short_open": EleutherTask("naturalqs_short_open", eleuther_metrics=True, model_args = {"max_gen_toks": 50}),
-    # hendrycksTest (57 tasks)
+    # hendrycksTest (MMLU) (57 tasks)
     **create_mmlu_tasks(),
     # "lambada": EleutherTask("lambada_standard").add_metrics(PERPLEXITY_METRICS).add_metric("acc", MeanMetric),
     # "pubmedqa": EleutherTaskWithRenamedSplits("pubmedqa").add_metrics(BINARY_CLASSIFICATION_METRICS),


### PR DESCRIPTION
Added MMLU task to catwalk
- All 57 tasks are added but have to be specified individually. Ideally we would have a Catwalk "GroupedTask" such that by only specifying `--task mmlu`, all the 57 tasks could be run. This would also allow us to aggregate the statistics across the subtasks. This seems beyond my ability but let me know if there is a simple fix.
- I am using the top-k dev examples as few-shot. The easiest way was to define a special `EleutherMMLUTask` for this
- I am using the `acc_raw` metric but I am not sure if that is the ideal one for MMLU.