### PR TITLE
Tokenizer remote code

### DIFF
--- a/catwalk/cached_transformers.py
+++ b/catwalk/cached_transformers.py
@@ -170,6 +170,7 @@ def get_tokenizer(cls: Type[T], model_name: str, **kwargs) -> T:
             kwargs['model_max_length'] = int(1e30)
         tokenizer = cls.from_pretrained(  # type: ignore
             model_name,
+            trust_remote_code=True, # Needed for some models, like Salesforce/xgen, ideally would be an option
             **kwargs,
         )
         _tokenizer_cache[cache_key] = tokenizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ wget
 datasets>=2.1.0
 accelerate
 bettermap
+tiktoken  # For Salesforce/xgen-* models
 
 # For the P3 datasets, which we get from huggingface datasets
 protobuf<=3.20


### PR DESCRIPTION
Add support for running Salesforce/xgen-* models - requires a hacky addition of `trust_remote_code=True` in the tokenizer loader, ideally this would be an explicit option.