### PR TITLE
Fix prefix space issues with certain tokenizers

### DIFF
--- a/catwalk/models/language_model.py
+++ b/catwalk/models/language_model.py
@@ -369,7 +369,7 @@ class DecoderOnlyLanguageModel(LanguageModel):
 
     @staticmethod
     def _prefix_with_space(s: str, needed=True) -> str:
-        if not s.startswith(' ') and not needed:
+        if not s.startswith(' ') and needed:
             return f" {s}"
         else:
             return s

--- a/catwalk/models/language_model.py
+++ b/catwalk/models/language_model.py
@@ -369,7 +369,9 @@ class DecoderOnlyLanguageModel(LanguageModel):
 
     @staticmethod
     def _prefix_with_space(s: str, needed=True) -> str:
-        if not s.startswith(' ') and needed:
+        if not needed and s.startswith(' '):
+            return s[1:]
+        elif not s.startswith(' ') and needed:
             return f" {s}"
         else:
             return s


### PR DESCRIPTION
This adds a heuristic to catch tokenizers (e.g., Llama) which treats a word starting a string has having a prefixed space, where previously the extra space added at the start of "continuations" in ranked classification task leads to a spurious space token (so for instance total probability mass over answer choices A/B/C/D in MC tasks drops from around 1 to near zero).