### PR TITLE
Add torch.no_grad, fix greedy_until bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Added `torch.no_grad()` around model calls in `language_model.py`
+- Prevent crashes with more robust stop token for `greedy_until` in `language_model.py`
+
 ## [v1.0.0rc0](https://github.com/allenai/catwalk/releases/tag/v1.0.0rc0) - 2023-12-19
 
 ### Added

--- a/catwalk/models/language_model.py
+++ b/catwalk/models/language_model.py
@@ -643,8 +643,8 @@ class DecoderOnlyLanguageModel(LanguageModel):
             if isinstance(untils, str):
                 untils = [untils]
             # if any of the stop phrases are single tokens we can use that for early termination
-            primary_until = None
-            for tokenized_until in tokenizer(untils)["input_ids"]:
+            primary_until = tokenizer.eos_token_id
+            for tokenized_until in tokenizer(untils, add_special_tokens=False)["input_ids"]:
                 if len(tokenized_until) == 1:
                     primary_until = tokenized_until[0]
 


### PR DESCRIPTION
This was an unnecessary oversight spotted by @jjyang77, that we're not wrapping model calls with `torch.no_grad()`. Added here for the `language_model.py` model type. In a couple of experiments it doesn't seem to speed evaluation up by much, but does improve memory usage (was able to run Llama-3-8B on single GPU rather than needing two).

Also fixed a bug in the `greedy_until` method which causes crashes for some models (like Mistral) when `primary_until` is set as `None`, as noted by @dmh43. 